### PR TITLE
Iterative Phase Estimation Sample code

### DIFF
--- a/binder-index.md
+++ b/binder-index.md
@@ -321,6 +321,14 @@ These are noted in the README.md files for each sample, along with complete inst
       <td>Q# standalone</td>
       <td></td>
     </tr>
+        <tr>
+      <td></td>
+      <td><strong><a href="./samples/characterization/iterative-phase-estimation/README.md">Iterative Phase Estimation</a></strong></td>
+      <td></td>
+      <td><a href="./samples/characterization/iterative-phase-estimation/iterative-phase-estimation.ipynb">Q# + Python</a></td>
+      <td></td>
+      <td></td>
+    </tr>
     <tr>
       <td></td>
       <td><strong><a href="./samples/characterization/process-tomography/README.md">Process tomography</a></strong></td>

--- a/samples/characterization/README.md
+++ b/samples/characterization/README.md
@@ -6,3 +6,5 @@ These samples demonstrate how to learn properties of quantum systems from classi
   This sample introduces the phase estimation algorithm, used to learn eigenvalues of various quantum operations.
 - **[Process Tomography](./process-tomography)**:
   This sample shows how to use Q# and Python together with the open systems simulator to learn evolution of noisy quantum systems.
+- **[Iterative Phase Estimation](./iterative-phase-estimation)**:
+  This sample uses iterative phase estimation to estimate the inner product of a specified pair of 2-d vectors. It is compatible with basic measurement feedback targets.

--- a/samples/characterization/iterative-phase-estimation/README.md
+++ b/samples/characterization/iterative-phase-estimation/README.md
@@ -1,0 +1,111 @@
+# Iterative Phase Estimation via the Cloud
+
+This sample code and notebook was written by members of KPMG Quantum team in Australia and falls under an MIT License. It aims to demonstrate expanded capabilities of Basic Measurement Feedback targets and makes use of bounded loops, classical function calls at run time, nested conditional if statements, mid circuit measurements and qubit reuse.
+
+### Two Dimensional Inner Product Using Three Qubits
+
+This notebook demonstrates an iterative phase estimation within Q#. The basic calculation it makes will be to calculate an inner product between two 2-dimensional vectors encoded on a target qubit and an ancilla qubit. An additional control qubit is also initialised, with a subsequent H gate applied. This control qubit will be used to readout the inner product via an iterative phase estimation. 
+
+The circuit begins by encoding the pair of vectors on the target qubit and the ancilla qubit. It then applies an Oracle operator to the entire register, controlled off the control qubit. The Oracle operator generates a eigenphase on the target and ancilla qubit register, which when controlled generates a phase on the |1> state of the control qubit. This can then be read by applying another H gate to the controlled qubit to make the phase observable when measuring the Z projection.
+
+
+## Encoding vectors
+
+The vectors v and c are to be encoded onto the target qubit. In two dimensions, the vectors are the angle about the Y axis on the Bloch Sphere. The state to be created is,
+
+$$\ket{\Psi}=\frac{1}{\sqrt{2}}(\ket{+}\ket{v}+\ket{-}\ket{c},$$
+
+which also takes the more readable form,
+
+$$\ket{\Psi} = \frac{1}{2}(\ket{v}+\ket{c})\ket{0}+\frac{1}{2}(\ket{v}-\ket{c})\ket{1}.$$
+
+Note that the angles represented as $\theta_1$ and $\theta_2$ are applied as $\frac{\theta_1}{2}$ and $\frac{\theta_2}{2}$. While the reason for this is not important, it is important to mention that coded values of  $\theta_1=0.0$ and $\theta_2=2.0\pi$ will calculate the inner product between vectors with actual angles $0$ and $\pi$ respectively (ie, anti-parallel).
+
+## The Oracle
+
+An oracle G needs to be constructed such that it generates an eigenphase on the state encoded on the target qubit and the ancilla qubit. The construction of this oracle is unimportant to the demonstration within this notebook, but the operation it applies is,
+
+$$G\ket \Psi = e^{2\pi i\theta} \ket \Psi.$$
+
+where the inner product $\braket {v|c}$ is contained within $\theta$. When applied controlled on the control qubit which begins in that state $\ket{\Psi_\text{Control Qubit}} = \ket +$,
+
+$$\begin{aligned}
+    \text{Controlled }G \ket{\Psi_\text{Control Qubit}} \ket \Psi  & = \frac {1}{\sqrt{2}} (\ket 0 \ket \Psi + e^{2\pi i\theta}\ket 1 \ket \Psi )\\
+    & =\frac {1}{\sqrt{2}} (\ket 0 + e^{2\pi i\theta}\ket 1) \ket \Psi
+\end{aligned}$$
+
+Now the control qubit contains the phase which relates to the inner product $\braket {v|c}$
+
+$$\ket{\Psi_\text{Control Qubit}} = \frac {1}{\sqrt{2}} (\ket 0 + e^{2\pi i\theta}\ket 1)$$
+
+## Iteration
+
+Now for the iterative part of the circuit. For n measurements, consider that the phase can be represented as a binary value $\theta$, and that applying $2^n$ oracles makes the nth binary point of the phase observable (through simple binary multiplication, and modulus $2\pi$). The value of the control qubit can be readout, placed in a classical register and the qubit reset for use in the next iteration. The next iteration applies $2^{n-1}$ oracles, correcting phase on the control qubit dependent on the nth measurement. The state on the control qubit can be represented as,
+
+$$ \ket {\Psi_{\text{Control Qubit}}} = \ket 0 + e^{2\pi i\theta}\ket 1 $$
+
+where $\theta = 0.\theta_0\theta_1\theta_2\theta_3$...
+
+Applying $2^n$ controlled oracles gives the state on the control qubit,
+
+$$ G^{2^n}\ket {\Psi_{\text{Control Qubit}}} = \ket 0 + e^{2\pi i 0.\theta_n\theta_{n+1}\theta_{n+2}\theta_{n+3}...}\ket 1 $$
+
+Consider that the phase has no terms deeper than $\theta_n$ (ie, terms $\theta_{n+1},\theta_{n+2}, \text{etc}$),
+
+$$ G^{2^n}\ket {\Psi_{\text{Control Qubit}}} = \ket 0 + e^{2\pi i 0.\theta_n}\ket 1 $$
+
+Now the value $\theta_n$ can be observed with a H gate and a measurement projecting along the Z axis. Resetting the control qubit and applying the oracle $2^{n-1}$ times,
+
+$$ G^{2^{n-1}}\ket {\Psi_{\text{Control Qubit}}} = \ket 0 + e^{2\pi i 0.\theta_{n-1}\theta_n}\ket 1 $$
+
+Using the previous measured value for $\theta_n$, the additional binary point can be rotated out.
+
+$$ RZ(-2\pi \times 0.0\theta_n)G^{n-1}\ket {\Psi_{\text{Control Qubit}}} = \ket 0 + e^{2\pi i 0.\theta_{n-1}}\ket 1 $$
+
+This process is iteratively applied for some bit precision n to obtain the phase $0.\theta_0\theta_1\theta_2...\theta_{n}$. The value is stored as a binary value $x = \theta_0\theta_1\theta_2...\theta_{n}$ as only integers are manipulatable at runtime currently.
+
+As the readout tells nothing of either vector, only the inner product between them, the states on the target qubit and ancilla qubit <u>remain in the same state</u> throughout the process!
+
+
+
+
+Finally to calculate the inner product from the measured value,
+
+$$\braket {v|c} = -cos(2\pi x / 2^n)$$
+
+where $x = \theta_0\theta_1\theta_2...\theta_{n}$. The denominator within the cosine function is to shift the binary point to match the original value $\theta$.
+
+**Note**: For inner product that are not -1 or 1, the solutions are paired with a value difference of $2^{n-1}$. For example for n=3 measurements, the measured bit value of 2 would also have a pair solution of 6. Either of these values produce the same value of the inner product when input as the variable to the even function cosine (resulting in an inner product of 0 in this example).
+
+**Note**: For inner product solutions between the discrete bit precision, a distribution of results will be produced based on where the inner product lies between the discrete bit value. 
+
+
+
+# Running using Azure CLI via VS Code
+
+## Simulating iterative phase estimation
+
+It is suggested that the SimulateInnerProduct is run first by placing "@EntryPoint()" before the operation SimulateInnerProduct and by using:
+
+**dotnet run**
+
+in the terminal before running on an Azure target. This version of the inner product operation will output additional information. This includes the manipulation of doubles of which the output is displayed in the terminal.
+
+## Running on an Azure target
+
+When running the job via the terminal using VS Code the following call should be made:
+
+**az quantum job submit --target-id quantinuum.sim.h1-1e --target-capability AdaptiveExecution --shots 128 --job-name IterativePhaseEstimation**
+
+**Note**: The target requires a target execution profile that supports basic measurement feedback.
+
+This will submit a job with the name "IterativePhaseEstimation". The circuit is approximately 1.2 HQC each shot. The number of shots specified is 128, but this can be increased to reduce the variance of the result, up to some stable distribution. It is not suggested to increase the number of measurements beyond 3 for running on Azure targets as the EHCs can increase significantly. Be sure to place "@EntryPoint()" before the operation InnerProduct, not SimulateInnerProduct as this operation contains calls such as "Message" which is only used for printing to the terminal within VS Code. Job data can be accessed as normal through the Azure portal or via the terminal using:
+
+**az quantum job output -j JOB_ID -o table**
+
+replacing "JOB_ID" with the job id. The results show a solution in the state with the majority population. The final inner product from the integer results can be calculated by $\braket {v|c} = -cos(2\pi x / 2^n)$, where n is the number of measurements specificed in the job.
+
+**Note**: Choosing input parameters which only has one solution state (inner produces of -1 or 1) are ideal for visibility at a low number of shots.
+
+
+

--- a/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.csproj
+++ b/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ExecutionTarget>quantinuum.sim.h1-1e</ExecutionTarget>
+  </PropertyGroup>
+</Project>

--- a/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.ipynb
+++ b/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.ipynb
@@ -1,0 +1,573 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Iterative Phase Estimation via the Cloud\r\n",
+        "\r\n",
+        "This sample code and notebook was written by members of KPMG Quantum team in Australia and falls under an MIT License. It aims to demonstrate expanded capabilities of Basic Measurement Feedback targets and makes use of bounded loops, classical function calls at run time, nested conditional if statements, mid circuit measurements and qubit reuse. \r\n",
+        "\r\n",
+        "\r\n",
+        "### Two Dimensional Inner Product Using Three Qubits\r\n",
+        "\r\n",
+        "This notebook demonstrates an iterative phase estimation within Q#. The basic calculation it makes will be to calculate an inner product between two 2-dimensional vectors encoded on a target qubit and an ancilla qubit. An additional control qubit is also initialised, with a subsequent H gate applied. This control qubit will be used to readout the inner product via an iterative phase estimation. \r\n",
+        "\r\n",
+        "The circuit begins by encoding the pair of vectors on the target qubit and the ancilla qubit. It then applies an Oracle operator to the entire register, controlled off the control qubit. The Oracle operator generates a eigenphase on the target and ancilla qubit register, which when controlled generates a phase on the |1> state of the control qubit. This can then be read by applying another H gate to the controlled qubit to make the phase observable when measuring the Z projection.\r\n",
+        "\r\n"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.connect \"\""
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##### Open Name Spaces Required\r\n",
+        "There are a number of Name Spaces required for this set of code. They are opened in the block below."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "open Microsoft.Quantum.Intrinsic;\r\n",
+        "open Microsoft.Quantum.Convert;\r\n",
+        "open Microsoft.Quantum.Math;\r\n",
+        "open Microsoft.Quantum.Arrays;\r\n",
+        "open Microsoft.Quantum.Measurement;"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Encoding vectors\r\n",
+        "\r\n",
+        "The vectors v and c are to be encoded onto the target qubit. In two dimensions, the vectors are the angle about the Y axis on the Bloch Sphere. The state to be created is,\r\n",
+        "\r\n",
+        "$$\\ket{\\Psi}=\\frac{1}{\\sqrt{2}}(\\ket{+}\\ket{v}+\\ket{-}\\ket{c},$$\r\n",
+        "\r\n",
+        "which also takes the more readable form,\r\n",
+        "\r\n",
+        "$$\\ket{\\Psi} = \\frac{1}{2}(\\ket{v}+\\ket{c})\\ket{0}+\\frac{1}{2}(\\ket{v}-\\ket{c})\\ket{1}.$$\r\n",
+        "\r\n",
+        "Note that the angles represented as $\\theta_1$ and $\\theta_2$ are applied as $\\frac{\\theta_1}{2}$ and $\\frac{\\theta_2}{2}$. While the reason for this is not important, it is important to mention that coded values of  $\\theta_1=0.0$ and $\\theta_2=2.0\\pi$ will calculate the inner product between vectors with actual angles $0$ and $\\pi$ respectively (ie, anti-parallel)."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "operation StateInitialisation(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double) : Unit is Adj + Ctl { //This is state preperation operator A for encoding the 2D vector (page 7)\r\n",
+        "    H(AncilReg);\r\n",
+        "\r\n",
+        "    Controlled R([AncilReg], (PauliY, -Theta1, TargetReg));        // Arbitrary controlled rotation based on theta. This is vector v.\r\n",
+        "                                                        \r\n",
+        "    X(AncilReg);                                                   // X gate on ancilla to change from |+> to |->.\r\n",
+        "    Controlled R([AncilReg], (PauliY, -Theta2, TargetReg));        // Arbitrary controlled rotation based on theta. This is vector c.\r\n",
+        "    X(AncilReg);                                                  \r\n",
+        "    H(AncilReg);                                                  \r\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## The Oracle\r\n",
+        "\r\n",
+        "An oracle G needs to be constructed such that it generates an eigenphase on the state encoded on the target qubit and the ancilla qubit. The construction of this oracle is unimportant to the demonstration within this notebook, but the operation it applies is,\r\n",
+        "\r\n",
+        "$$G\\ket \\Psi = e^{2\\pi i\\theta} \\ket \\Psi.$$\r\n",
+        "\r\n",
+        "where the inner product $\\braket {v|c}$ is contained within $\\theta$. When applied controlled on the control qubit which begins in that state $\\ket{\\Psi_\\text{Control Qubit}} = \\ket +$,\r\n",
+        "\r\n",
+        "$$\\begin{aligned}\r\n",
+        "    \\text{Controlled }G \\ket{\\Psi_\\text{Control Qubit}} \\ket \\Psi  & = \\frac {1}{\\sqrt{2}} (\\ket 0 \\ket \\Psi + e^{2\\pi i\\theta}\\ket 1 \\ket \\Psi )\\\\\r\n",
+        "    & =\\frac {1}{\\sqrt{2}} (\\ket 0 + e^{2\\pi i\\theta}\\ket 1) \\ket \\Psi\r\n",
+        "\\end{aligned}$$\r\n",
+        "\r\n",
+        "Now the control qubit contains the phase which relates to the inner product $\\braket {v|c}$\r\n",
+        "\r\n",
+        "$$\\ket{\\Psi_\\text{Control Qubit}} = \\frac {1}{\\sqrt{2}} (\\ket 0 + e^{2\\pi i\\theta}\\ket 1)$$"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "operation GOracle(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double) : Unit is Adj + Ctl {\r\n",
+        "    Z(AncilReg);                                                      \r\n",
+        "    Adjoint StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);\r\n",
+        "    X(AncilReg);                                                        // Apply X gates individually here as currently ApplyAll is not Adj + Ctl\r\n",
+        "    X(TargetReg);\r\n",
+        "    Controlled Z([AncilReg],TargetReg);\r\n",
+        "    X(AncilReg);\r\n",
+        "    X(TargetReg);\r\n",
+        "    StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);         \r\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Iteration\r\n",
+        "\r\n",
+        "Now for the iterative part of the circuit. For n measurements, consider that the phase can be represented as a binary value $\\theta$, and that applying $2^n$ oracles makes the nth binary point of the phase observable (through simple binary multiplication, and modulus $2\\pi$). The value of the control qubit can be readout, placed in a classical register and the qubit reset for use in the next iteration. The next iteration applies $2^{n-1}$ oracles, correcting phase on the control qubit dependent on the nth measurement. The state on the control qubit can be represented as,\r\n",
+        "\r\n",
+        "$$ \\ket {\\Psi_{\\text{Control Qubit}}} = \\ket 0 + e^{2\\pi i\\theta}\\ket 1 $$\r\n",
+        "\r\n",
+        "where $\\theta = 0.\\theta_0\\theta_1\\theta_2\\theta_3$...\r\n",
+        "\r\n",
+        "Applying $2^n$ controlled oracles gives the state on the control qubit,\r\n",
+        "\r\n",
+        "$$ G^{2^n}\\ket {\\Psi_{\\text{Control Qubit}}} = \\ket 0 + e^{2\\pi i 0.\\theta_n\\theta_{n+1}\\theta_{n+2}\\theta_{n+3}...}\\ket 1 $$\r\n",
+        "\r\n",
+        "Consider that the phase has no terms deeper than $\\theta_n$ (ie, terms $\\theta_{n+1},\\theta_{n+2}, \\text{etc}$),\r\n",
+        "\r\n",
+        "$$ G^{2^n}\\ket {\\Psi_{\\text{Control Qubit}}} = \\ket 0 + e^{2\\pi i 0.\\theta_n}\\ket 1 $$\r\n",
+        "\r\n",
+        "Now the value $\\theta_n$ can be observed with a H gate and a measurement projecting along the Z axis. Resetting the control qubit and applying the oracle $2^{n-1}$ times,\r\n",
+        "\r\n",
+        "$$ G^{2^{n-1}}\\ket {\\Psi_{\\text{Control Qubit}}} = \\ket 0 + e^{2\\pi i 0.\\theta_{n-1}\\theta_n}\\ket 1 $$\r\n",
+        "\r\n",
+        "Using the previous measured value for $\\theta_n$, the additional binary point can be rotated out.\r\n",
+        "\r\n",
+        "$$ RZ(-2\\pi \\times 0.0\\theta_n)G^{n-1}\\ket {\\Psi_{\\text{Control Qubit}}} = \\ket 0 + e^{2\\pi i 0.\\theta_{n-1}}\\ket 1 $$\r\n",
+        "\r\n",
+        "This process is iteratively applied for some bit precision n to obtain the phase $0.\\theta_0\\theta_1\\theta_2...\\theta_{n}$. The value is stored as a binary value $x = \\theta_0\\theta_1\\theta_2...\\theta_{n}$ as only integers are manipulatable at runtime currently.\r\n",
+        "\r\n",
+        "As the readout tells nothing of either vector, only the inner product between them, the states on the target qubit and ancilla qubit <u>remain in the same state</u> throughout the process!"
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "operation IterativePhaseEstimation(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double, Measurements : Int) : Int{\r\n",
+        "    use ControlReg = Qubit();\r\n",
+        "    mutable MeasureControlReg = ConstantArray(Measurements, Zero);                                  //Set up array of measurement results of zero\r\n",
+        "    mutable bitValue = 0;\r\n",
+        "    StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);                                       //Apply to initialise state, this is defined by the angles theta1 and theta2\r\n",
+        "    for index in 0 .. Measurements - 1{                                                             \r\n",
+        "        H(ControlReg);                                                                              \r\n",
+        "        if index > 0 {                                                                              //Don't apply rotation on first set of oracles\r\n",
+        "            for index2 in 0 .. index - 1{                                                           //Loop through previous results\r\n",
+        "                if MeasureControlReg[Measurements - 1 - index2] == One{                             \r\n",
+        "                    R(PauliZ, -IntAsDouble(2^(index2))*PI()/(2.0^IntAsDouble(index)), ControlReg);  \r\n",
+        "                }\r\n",
+        "            }\r\n",
+        "            \r\n",
+        "        }\r\n",
+        "        let powerIndex = (1 <<< (Measurements - 1 - index));\r\n",
+        "        for _ in 1 .. powerIndex{                                                                   //Apply a number of oracles equal to 2^index, where index is the number or measurements left\r\n",
+        "                Controlled GOracle([ControlReg],(TargetReg, AncilReg, Theta1, Theta2));\r\n",
+        "            }\r\n",
+        "        H(ControlReg);\r\n",
+        "        set MeasureControlReg w/= (Measurements - 1 - index) <- MResetZ(ControlReg);                //Make a measurement mid circuit \r\n",
+        "        if MeasureControlReg[Measurements - 1 - index] == One{\r\n",
+        "            set bitValue += 2^(index);                                                              //Assign bitValue based on previous measurement\r\n",
+        "                                                                                                    \r\n",
+        "        }\r\n",
+        "    }\r\n",
+        "    Reset(ControlReg);                                                                              //Reset qubits for end of circuit.\r\n",
+        "    Reset(TargetReg);                                           \r\n",
+        "    Reset(AncilReg); \r\n",
+        "    return bitValue;\r\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Finally to calculate the inner product from the measured value,\r\n",
+        "\r\n",
+        "$$\\braket {v|c} = -cos(2\\pi x / 2^n)$$\r\n",
+        "\r\n",
+        "where $x = \\theta_0\\theta_1\\theta_2...\\theta_{n}$. The denominator within the cosine function is to shift the binary point to match the original value $\\theta$.\r\n",
+        "\r\n",
+        "**Note**: For inner product that are not -1 or 1, the solutions are paired with a value difference of $2^{n-1}$. For example for n=3 measurements, the measured bit value of 2 would also have a pair solution of 6. Either of these values produce the same value of the inner product when input as the variable to the even function cosine (resulting in an inner product of 0 in this example).\r\n",
+        "\r\n",
+        "**Note**: For inner product solutions between the discrete bit precision, a distribution of results will be produced based on where the inner product lies between the discrete bit value. "
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "operation SimulateInnerProduct() : Int{\r\n",
+        "    let Theta1 = 0.0;                                                                           //Specify the angles for inner product\r\n",
+        "    let Theta2 = 0.0;\r\n",
+        "    let Measurements = 3;                                                                       //Specify the bit resolution in the iterative phase estimation\r\n",
+        "                                                                                                //For Jobs on hardware the suggested number of measurements is 3\r\n",
+        "    use TargetReg = Qubit();                                                                    //TargetReg has states v and c qubits contained on it\r\n",
+        "    use AncilReg = Qubit();                                                                     //Create ancilla\r\n",
+        "    let Results = IterativePhaseEstimation(TargetReg, AncilReg, Theta1, Theta2, Measurements);  //This runs iterative phase estimation\r\n",
+        "    \r\n",
+        "\r\n",
+        "    let DoubleVal = PI() * IntAsDouble(Results) / IntAsDouble(2 ^ (Measurements-1));\r\n",
+        "    let InnerProductValue = -Cos(DoubleVal);                                                      //Convert to the final inner product\r\n",
+        "    Message(\"The Inner Product is:\");\r\n",
+        "    Message($\"{InnerProductValue}\");\r\n",
+        "    Message(\"The True Inner Product is:\");\r\n",
+        "    Message($\"{Cos(Theta1/2.0)*Cos(Theta2/2.0)+Sin(Theta1/2.0)*Sin(Theta2/2.0)}\");\r\n",
+        "    Message(\"The Bit Value measured is\");\r\n",
+        "\r\n",
+        "                                                                            \r\n",
+        "    return Results;                                                                             //Return Measured values\r\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%simulate SimulateInnerProduct"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The inner product operation is reconstructed to fit within the requirements of the target. In this case, calls like \"Message\" and manipulation of doubles is not allowed. Therefore the output will be the bit value as generated by the IterativePhaseEstimation operation."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "operation InnerProduct() : Int{\r\n",
+        "    let Theta1 = 0.0;                                                                           //Specify the angles for inner product\r\n",
+        "    let Theta2 = 0.0;\r\n",
+        "    let Measurements = 3;                                                                       //Specify the bit resolution in the iterative phase estimation\r\n",
+        "                                                                                                //For Jobs on hardware the suggested number of measurements is 3\r\n",
+        "    use TargetReg = Qubit();                                                                    //TargetReg has states v and c qubits contained on it\r\n",
+        "    use AncilReg = Qubit();                                                                     //Create ancilla\r\n",
+        "    let Results = IterativePhaseEstimation(TargetReg, AncilReg, Theta1, Theta2, Measurements);  //This runs iterative phase estimation\r\n",
+        "                                                                           \r\n",
+        "    return Results;                                                                             //Return Measured values\r\n",
+        "}"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Specify the target.\r\n",
+        "\r\n",
+        "**Note**: The target requires a target execution profile that supports basic measurement feedback."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.target quantinuum.sim.h1-1e"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.target-capability AdaptiveExecution"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Submit the job to the target. The circuit is approximately 1.2 HQC each shot. The number of shots specified is 128, but this can be increased to reduce the variance of the result, up to some stable distribution.\r\n",
+        "\r\n",
+        "**Note**: Choosing input parameters which only has one solution state (inner produces of -1 or 1) are ideal for visibility at a low number of shots."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.submit InnerProduct shots = 128\r\n"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Check the status of the job specified."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.status"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "When the job is complete, output a histogram of results.\r\n",
+        "\r\n",
+        "The results should show a majority in the solution states."
+      ],
+      "metadata": {
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "%azure.output"
+      ],
+      "outputs": [],
+      "execution_count": null,
+      "metadata": {
+        "jupyter": {
+          "source_hidden": false,
+          "outputs_hidden": false
+        },
+        "nteract": {
+          "transient": {
+            "deleting": false
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "qsharp",
+      "version": "0.27",
+      "mimetype": "text/x-qsharp",
+      "file_extension": ".qs"
+    },
+    "kernelspec": {
+      "name": "iqsharp",
+      "language": "qsharp",
+      "display_name": "Q#"
+    },
+    "kernel_info": {
+      "name": "iqsharp"
+    },
+    "nteract": {
+      "version": "nteract-front-end@1.0.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.qs
+++ b/samples/characterization/iterative-phase-estimation/iterative-phase-estimation.qs
@@ -1,0 +1,110 @@
+
+namespace IPE {
+    //IMPORT LIBRARIES
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Convert;
+
+
+
+    operation StateInitialisation(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double) : Unit is Adj + Ctl { //This is state preperation operator A for encoding the 2D vector (page 7)
+        H(AncilReg);
+
+        Controlled R([AncilReg], (PauliY, -Theta1, TargetReg));        // Arbitrary controlled rotation based on theta. This is vector v.
+                                                            
+        X(AncilReg);                                                   // X gate on ancilla to change from |+> to |->.
+        Controlled R([AncilReg], (PauliY, -Theta2, TargetReg));        // Arbitrary controlled rotation based on theta. This is vector c.
+        X(AncilReg);                                                  
+        H(AncilReg);                                                  
+    }
+
+
+
+     operation GOracle(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double) : Unit is Adj + Ctl {
+        Z(AncilReg);                                                      
+        Adjoint StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);
+        X(AncilReg);                                                        // Apply X gates individually here as currently ApplyAll is not Adj + Ctl
+        X(TargetReg);
+        Controlled Z([AncilReg],TargetReg);
+        X(AncilReg);
+        X(TargetReg);
+        StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);         
+    }
+
+
+
+    operation IterativePhaseEstimation(TargetReg : Qubit, AncilReg : Qubit, Theta1 : Double, Theta2 : Double, Measurements : Int) : Int{
+        use ControlReg = Qubit();
+        mutable MeasureControlReg = ConstantArray(Measurements, Zero);                                  //Set up array of measurement results of zero
+        mutable bitValue = 0;
+        StateInitialisation(TargetReg, AncilReg, Theta1, Theta2);                                       //Apply to initialise state, this is defined by the angles theta1 and theta2
+        for index in 0 .. Measurements - 1{                                                             
+            H(ControlReg);                                                                              
+            if index > 0 {                                                                              //Don't apply rotation on first set of oracles
+                for index2 in 0 .. index - 1{                                                           //Loop through previous results
+                    if MeasureControlReg[Measurements - 1 - index2] == One{                             
+                        R(PauliZ, -IntAsDouble(2^(index2))*PI()/(2.0^IntAsDouble(index)), ControlReg);  
+                    }
+                }
+                
+            }
+            let powerIndex = (1 <<< (Measurements - 1 - index));
+            for _ in 1 .. powerIndex{                                                                   //Apply a number of oracles equal to 2^index, where index is the number or measurements left
+                    Controlled GOracle([ControlReg],(TargetReg, AncilReg, Theta1, Theta2));
+                }
+            H(ControlReg);
+            set MeasureControlReg w/= (Measurements - 1 - index) <- MResetZ(ControlReg);                //Make a measurement mid circuit 
+            if MeasureControlReg[Measurements - 1 - index] == One{
+                set bitValue += 2^(index);                                                              //Assign bitValue based on previous measurement
+                                                                                                        
+            }
+        }
+        Reset(ControlReg);                                                                              //Reset qubits for end of circuit.
+        Reset(TargetReg);                                           
+        Reset(AncilReg); 
+        return bitValue;
+    }
+
+    
+    
+    operation SimulateInnerProduct() : Int{
+        let Theta1 = 0.0;                                                                           //Specify the angles for inner product
+        let Theta2 = 0.0;
+        let Measurements = 3;                                                                       //Specify the bit resolution in the iterative phase estimation
+                                                                                                    //For Jobs on hardware the suggested number of measurements is 3
+        use TargetReg = Qubit();                                                                    //TargetReg has states v and c qubits contained on it
+        use AncilReg = Qubit();                                                                     //Create ancilla
+        let Results = IterativePhaseEstimation(TargetReg, AncilReg, Theta1, Theta2, Measurements);  //This runs iterative phase estimation
+        
+
+        let DoubleVal = PI() * IntAsDouble(Results) / IntAsDouble(2 ^ (Measurements-1));
+        let InnerProductValue = -Cos(DoubleVal);                                                      //Convert to the final inner product
+        Message("The Inner Product is:");
+        Message($"{InnerProductValue}");
+        Message("The True Inner Product is:");
+        Message($"{Cos(Theta1/2.0)*Cos(Theta2/2.0)+Sin(Theta1/2.0)*Sin(Theta2/2.0)}");
+        Message("The Bit Value measured is");
+
+                                                                                
+        return Results;                                                                             //Return Measured values
+    }
+
+
+
+    @EntryPoint()
+    operation InnerProduct() : Int{
+        let Theta1 = 0.0;                                                                           //Specify the angles for inner product
+        let Theta2 = 0.0;
+        let Measurements = 3;                                                                       //Specify the bit resolution in the iterative phase estimation
+                                                                                                    //For Jobs on hardware the suggested number of measurements is 3
+        use TargetReg = Qubit();                                                                    //TargetReg has states v and c qubits contained on it
+        use AncilReg = Qubit();                                                                     //Create ancilla
+        let Results = IterativePhaseEstimation(TargetReg, AncilReg, Theta1, Theta2, Measurements);  //This runs iterative phase estimation
+                                                                            
+        return Results;                                                                             //Return Measured values
+    }
+    
+
+}


### PR DESCRIPTION
Iterative Phase Estimation for Basic Measurement Feedback targets by KPMG. 

Runnable on targets via the L3 level QIR, using bounded loops, classical function calls at runtime, nested if conditionals, mid circuit measurement and qubit reuse. Uses approximately 150 EHCs for Quantinuum targets and runnable within 5 minutes of opening notebook.